### PR TITLE
Update add_lead_in_messages.py

### DIFF
--- a/tools/add_lead_in_messages.py
+++ b/tools/add_lead_in_messages.py
@@ -103,7 +103,7 @@ def addLeadInMessage(inputPath, outputPath):
 def detectAudioData(mp3File):
     try:
         output = subprocess.check_output([ 'ffmpeg', '-i', mp3File, '-hide_banner' ], stderr=subprocess.STDOUT)
-    except Exception, e:
+    except Exception as e:
         output = str(e.output)
 
     match = re.match('.*Stream #\\d+:\\d+: Audio: mp3, (\\d+) Hz, (mono|stereo), .*', output, re.S)


### PR DESCRIPTION
Sowohl unter Windows 10 (Python 3.7) als auch unter Ubuntu 16.04 (Python 3.5) hat das Skript einen Syntaxfehler geworfen. Das waren die beiden Systeme, die ich grade da hatte und der Fehler ließ sich durch diese kleine Änderung beheben.