### PR TITLE
Update text_to_speech.py

### DIFF
--- a/tools/text_to_speech.py
+++ b/tools/text_to_speech.py
@@ -98,7 +98,7 @@ def postJson(url, postBody, headers = None):
             cmd.extend(['-H', header])
     cmd.extend(['-H', 'Content-Type: application/json; charset=utf-8', '--data', json.dumps(postBody).encode('utf-8'), url])
     response = subprocess.check_output(cmd)
-    return json.loads(response)
+    return json.loads(response.decode('utf-8'))
 
 
 def postForm(url, formData):


### PR DESCRIPTION
curl liefert anscheinend ein byte Objekt zurück. Ohne decode gibts hier den Fehler "TypeError: the JSON object must be str, not 'bytes'".