### PR TITLE
Improvements for Text-to-Speech scripts

### DIFF
--- a/tools/add_lead_in_messages.py
+++ b/tools/add_lead_in_messages.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 # Adds a lead-in message to each mp3 file of a directory storing the result in another directory.
 # So - when played e.g. on a TonUINO - you first will hear the title of the track, then the track itself.

--- a/tools/add_lead_in_messages.py
+++ b/tools/add_lead_in_messages.py
@@ -79,6 +79,8 @@ def addLeadInMessage(inputPath, outputPath):
     if not args.dry_run:
         tempLeadInFile = 'temp-lead-in.mp3'
         tempLeadInFileAdjusted = 'temp-lead-in_adjusted.mp3'
+        tempListFile = 'temp-list.txt'
+        tempTargetFile = 'temp-target.mp3'
         text_to_speech.textToSpeechUsingArgs(text=text, targetFile=tempLeadInFile, args=args)
 
         # Adjust sample rate and mono/stereo
@@ -93,10 +95,19 @@ def addLeadInMessage(inputPath, outputPath):
             subprocess.call([ 'ffmpeg', '-i', tempLeadInFile, '-vn', '-ar', detectionInfo['sampleRate'], '-ac', detectionInfo['channels'], tempLeadInFileAdjusted ])
 
         print('Concat')
-        subprocess.call([ 'ffmpeg', '-i', 'concat:{}|{}'.format(tempLeadInFileAdjusted, inputPath), '-acodec', 'copy', outputPath, '-map_metadata', '0:1' ])
+        # Use ffmpeg Concat demuxer
+        with open(tempListFile, 'w') as f:
+            f.write("file " + "'" + tempLeadInFileAdjusted + "'")
+            f.write("\n")
+            f.write("file " + "'" + inputPath + "'")
+        subprocess.call([ 'ffmpeg', '-f', 'concat', '-safe', '0', '-i', tempListFile, '-c', 'copy', tempTargetFile ])
+        # Copy metadata from input file
+        subprocess.call([ 'ffmpeg', '-i', inputPath, '-i', tempTargetFile, '-map', '1', '-c', 'copy', '-map_metadata', '0', outputPath ])
 
         os.remove(tempLeadInFile)
         os.remove(tempLeadInFileAdjusted)
+        os.remove(tempListFile)
+        os.remove(tempTargetFile)
         print('\n')
 
 

--- a/tools/create_audio_messages.py
+++ b/tools/create_audio_messages.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 # Creates the audio messages needed by TonUINO.
 

--- a/tools/text_to_speech.py
+++ b/tools/text_to_speech.py
@@ -1,10 +1,13 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 # Converts text into spoken language saved to an mp3 file.
 
 
-import argparse, base64, json, os, subprocess, sys, urllib.request
-
+import argparse, base64, json, os, subprocess, sys
+try:
+    import urllib.request
+except ImportError:
+    print("WARNING: It looks like your are using an old Python version. Please use Python 3 if you intend to Google Text to Speech.")
 
 class PatchedArgumentParser(argparse.ArgumentParser):
     def error(self, message):

--- a/tools/text_to_speech.py
+++ b/tools/text_to_speech.py
@@ -3,7 +3,7 @@
 # Converts text into spoken language saved to an mp3 file.
 
 
-import argparse, base64, json, os, subprocess, sys, urllib
+import argparse, base64, json, os, subprocess, sys, urllib.request
 
 
 class PatchedArgumentParser(argparse.ArgumentParser):
@@ -91,19 +91,16 @@ def textToSpeech(text, targetFile, lang='de', useAmazon=False, useGoogleKey=None
         os.remove('temp.aiff')
 
 
-def postJson(url, postBody, headers = None):
-    cmd = ['curl']
-    if headers is not None:
-        for header in headers:
-            cmd.extend(['-H', header])
-    cmd.extend(['-H', 'Content-Type: application/json; charset=utf-8', '--data', json.dumps(postBody).encode('utf-8'), url])
-    response = subprocess.check_output(cmd)
-    return json.loads(response.decode('utf-8'))
-
-
-def postForm(url, formData):
-    response = subprocess.check_output(['curl', '-H', 'Content-Type: application/x-www-form-urlencoded; charset=utf-8', '--data', urllib.urlencode(formData), url])
-    return json.loads(response)
+def postJson(postUrl, postBody, headers = {}):
+    headers['Content-Type'] = 'application/json; charset=utf-8'
+    postData = json.dumps(postBody).encode('utf-8')
+    try:
+        postRequest = urllib.request.Request(postUrl, postData, headers)
+        with urllib.request.urlopen(postRequest) as req:
+            postResponseData=req.read()
+        return json.loads(postResponseData.decode())
+    except Exception as e:
+        print(e)
 
 
 if __name__ == '__main__':

--- a/tools/text_to_speech.py
+++ b/tools/text_to_speech.py
@@ -7,7 +7,7 @@ import argparse, base64, json, os, subprocess, sys
 try:
     import urllib.request
 except ImportError:
-    print("WARNING: It looks like your are using an old Python version. Please use Python 3 if you intend to Google Text to Speech.")
+    print("WARNING: It looks like your are using an old Python version. Please use Python 3 if you intend to use Google Text to Speech.")
 
 class PatchedArgumentParser(argparse.ArgumentParser):
     def error(self, message):

--- a/tools/text_to_speech.py
+++ b/tools/text_to_speech.py
@@ -7,7 +7,7 @@ import argparse, base64, json, os, subprocess, sys
 try:
     import urllib.request
 except ImportError:
-    print("WARNING: It looks like your are using an old Python version. Please use Python 3 if you intend to use Google Text to Speech.")
+    print("WARNING: It looks like you are using an old version of Python. Please use Python 3 if you intend to use Google Text to Speech.")
 
 class PatchedArgumentParser(argparse.ArgumentParser):
     def error(self, message):


### PR DESCRIPTION
- The scripts now work on Linux and Windows
- Curl is not needed any more. 
- Improved the ffmpeg call. It uses the concat demuxer (stream copy) now instead of the protocol (file copy). This fixes a problem that the merged mp3s were cut off at the beginning in some cases / on some DFPlayers.
- The mp3 metadata is copied from the source to the destination file
