### PR TITLE
Pio defines

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,16 @@
+[platformio]
+src_dir  = .
+
+[env:nanoatmega328]
+platform = atmelavr
+board = nanoatmega328
+framework = arduino
+monitor_speed = 9600
+
+lib_deps = 	
+	miguelbalboa/MFRC522
+	makuna/DFPlayer Mini Mp3 by Makuna @ 1.0.7
+	bxparks/AceButton
+	https://github.com/z3t0/Arduino-IRremote
+	https://github.com/cpldcpu/light_ws2812
+	https://github.com/Yveaux/Arduino_Vcc

--- a/platformio.ini
+++ b/platformio.ini
@@ -14,3 +14,25 @@ lib_deps =
 	https://github.com/z3t0/Arduino-IRremote
 	https://github.com/cpldcpu/light_ws2812
 	https://github.com/Yveaux/Arduino_Vcc
+
+build_flags =
+	; uncomment the below line to enable five button support
+	; -D FIVEBUTTONS
+
+	; uncomment the below line to enable ir remote support
+	; -D IRREMOTE
+
+	; uncomment the below line to enable pin code support
+	; -D PINCODE
+
+	; uncomment ONE OF THE BELOW TWO LINES to enable status led support
+	; the first enables support for a vanilla led
+	; the second enables support for ws281x led(s)
+	; -D STATUSLED
+	; -D STATUSLEDRGB
+
+	; uncomment the below line to enable low voltage shutdown support
+	; -D LOWVOLTAGE
+
+	; uncomment the below line to flip the shutdown pin logic
+	; -D POLOLUSWITCH


### PR DESCRIPTION
This is an extension to the initial PlatformIO config for this project (see #26).
If you like it, you can merge it.

Took library list from code, but not all libraries are supported by PIO.

Also had to pin DFPlayer Mini to specific version due to incompatible API change.